### PR TITLE
Fix getenv value for SONIA_WS

### DIFF
--- a/src/sonia_common/config.h
+++ b/src/sonia_common/config.h
@@ -34,9 +34,9 @@ namespace sonia_common {
 
 /// The path where the system will save all the configurations.
 #ifdef OS_DARWIN
-const std::string kWorkspaceRoot = getenv("ROS_SONIA_WS");
+const std::string kWorkspaceRoot = std::getenv("ROS_WS_SETUP");
 #else
-const std::string kWorkspaceRoot = std::getenv("ROS_SONIA_WS");
+const std::string kWorkspaceRoot = std::getenv("ROS_WS_SETUP");
 #endif
 
 /// The path where the system will save all the log files (e.g. from Logger).


### PR DESCRIPTION
## Description
Modify the name of the env var for SONIA workspace.
The process is terminated if the env var is not found due to NULL returned to init the string.

## Fixes
Link all the related issues from the issue tracker
(I don't think there's an issue for this one)

## How has this been tested ?
Tested with proc_image_processing using docker

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings