### PR TITLE
change definition for kill and backplane IO to do

### DIFF
--- a/msg/SendRS485Msg.msg
+++ b/msg/SendRS485Msg.msg
@@ -1,53 +1,23 @@
 # SLAVE ID
 
-uint8 SLAVE_powersupply0 = 49
-uint8 SLAVE_powersupply1 = 50
-uint8 SLAVE_powersupply2 = 51
-uint8 SLAVE_powersupply3 = 52
-uint8 SLAVE_killMission = 32
-uint8 SLAVE_ISI_PWM = 16
-uint8 SLAVE_ISI_1 = 17
-uint8 SLAVE_ISI_2 = 18
-uint8 SLAVE_ISI_3 = 19
-uint8 SLAVE_ISI_4 = 20
-uint8 SLAVE_ISI_5 = 21
-uint8 SLAVE_ISI_6 = 22
-uint8 SLAVE_ISI_7 = 23
-uint8 SLAVE_ISI_8 = 24
-uint8 SLAVE_IO_CTR = 64
+uint8 SLAVE_BACKPLANE = 0
+uint8 SLAVE_IO = 1
+uint8 SALVE_KILLMISSION = 2
 
 #CMD
+
 # les define de la kill mission switch
-uint8 CMD_MISSION  		    =0
-uint8 CMD_KILL	  		    =1
-# les define du powersupply
-uint8 CMD_PS_V16_1  		=0
-uint8 CMD_PS_V16_2	     	=1
-uint8 CMD_PS_V12	  		=2
-uint8 CMD_PS_C16_1	    	=3
-uint8 CMD_PS_C16_2	  	    =4
-uint8 CMD_PS_C12	  		=5
-uint8 CMD_PS_temperature	=6
-uint8 CMD_PS_VBatt		    =7
+uint8 CMD_MISSION = 0
+uint8 CMD_KILL = 1
 
- #define de ISI
-uint8 CMD_ISI_power = 0
+# les define de la backplane
+uint8 CMD_VOLTAGE = 0
+uint8 CMD_CURRENT = 1
+uint8 CMD_READ_MOTOR = 2
+uint8 CMD_ACT_MOTOR = 3
+uint8 CMD_PWM = 4
 
-uint8 CMD_PS_ACT_12V        = 16
-uint8 CMD_PS_ACT_16V_1      = 17
-uint8 CMD_PS_ACT_16V_2      = 18
-
-uint8 CMD_PS_CHECK_12V        = 19
-uint8 CMD_PS_CHECK_16V_1      = 20
-uint8 CMD_PS_CHECK_16V_2      = 21
-
-uint8 CMD_IO_ARM_OPEN       = 22
-uint8 CMD_IO_ARM_CLOSE      = 23
-
-
-uint8 CMD_POWERSUPPLY_action1 = 2
-
-# define IO CONTROL
+# define IO CONTROL (TBD)
 uint8 CMD_IO_TEMP = 0
 uint8 CMD_IO_DROPPER_PORT = 1
 uint8 CMD_IO_DROPPER_STARBOARD = 2


### PR DESCRIPTION
**Warning :** Before creating a pull request, make sure that it does not already exists in the [pull requests](../). Thank you.

## Description
Change the RS485 definition for the backplane and Killswitch. Affected provider have been modified

## How has this been tested ?
Tested each provider affected

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings