### PR TITLE
Fix/serial device

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV BASE_LIB_PATH=${BASE_LIB_WS}/src/${BASE_LIB_NAME}
 
 ## ADD EXTRA DEPENDENCIES (GIT and ROS Remote Debuging)
 RUN apt update && apt install -y libyaml-cpp-dev openssh-client gdb ros-noetic-diagnostics git sudo ninja-build
+RUN apt upgrade -y
 RUN rm -rf /var/lib/apt/lists/*
 
 RUN useradd --uid ${SONIA_UID} --create-home ${SONIA_USER} -G sudo

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>sonia_common</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>sonia_common</description>
   <maintainer email="club.sonia@etsmtl.net">Club SONIA</maintainer>
   <license>GPLv3</license>


### PR DESCRIPTION
**Warning :** Before creating a pull request, make sure that it does not already exists in the [pull requests](../). Thank you.

## Description
Placed the fix of @0x72D0 in the base dockerfile to reduce the amount of dockerfile to change and reduce the error of forgetting it if we add new sensors. This fix enable the USB / serial to be used at it full potential

## How has this been tested ?
Tested locally with the depth sensor Results with a `rostopic hz /provider_depth/depth` :
![Screenshot from 2022-02-22 16-21-17](https://user-images.githubusercontent.com/44241055/155221859-9c22b9c9-f1ee-4df8-b62e-9b6f0baa3d90.png)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings