### PR TITLE
managed case when ROS_WS_SETUP is not set (in local use)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>sonia_common</name>
-  <version>1.1.7</version>
+  <version>1.1.8</version>
   <description>sonia_common</description>
   <maintainer email="club.sonia@etsmtl.net">Club SONIA</maintainer>
   <license>GPLv3</license>

--- a/src/sonia_common/config.h
+++ b/src/sonia_common/config.h
@@ -34,9 +34,9 @@ namespace sonia_common {
 
 /// The path where the system will save all the configurations.
 #ifdef OS_DARWIN
-    const std::string kWorkspaceRoot = std::getenv("ROS_WS_SETUP");
+    const std::string kWorkspaceRoot = std::getenv("ROS_WS_SETUP") ? std::getenv("ROS_WS_SETUP") : "/opt/ros/noetic/setup.bash";
 #else
-    const std::string kWorkspaceRoot = std::getenv("ROS_WS_SETUP");
+    const std::string kWorkspaceRoot = std::getenv("ROS_WS_SETUP") ? std::getenv("ROS_WS_SETUP") : "/opt/ros/noetic/setup.bash";
 #endif
 
 /// The path where the system will save all the log files (e.g. from Logger).


### PR DESCRIPTION
**Warning :** Before creating a pull request, make sure that it does not already exists in the [pull requests](../). Thank you.

## Description
Managed the case when ROS_WS_SETUP was no set and it would cause proc_image_processing to crash.

## How has this been tested ?
Tested locally.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings